### PR TITLE
Fix Epic Games Auth and Notification

### DIFF
--- a/helper/app_finder.py
+++ b/helper/app_finder.py
@@ -76,7 +76,7 @@ def gather_msstore(id, market):
 
 
 def gather_epicgames():
-    _client = LegendaryCLI()
+    _client = LegendaryCLI(api_timeout=10.0)
     _client.core.login()
     _product_infos, _ = _client.core.get_game_and_dlc_list()
 
@@ -86,7 +86,7 @@ def gather_epicgames():
         _data = vars(_product_info)
         _id = _data["app_name"]
         _name = _data["app_title"]
-        _version = _data["asset_info"]["build_version"]
+        _version = _data["asset_infos"]["Windows"]["build_version"]
 
         _row = [_id, _id, _name, _version]
         _table.append(_row)

--- a/helper/epicgames_auth.py
+++ b/helper/epicgames_auth.py
@@ -2,7 +2,7 @@ from legendary.cli import LegendaryCLI
 
 
 def main():
-    _client = LegendaryCLI()
+    _client = LegendaryCLI(api_timeout=10.0)
     _args = {
         "import_egs_auth": None,
         "auth_code": None,

--- a/modules/epicgames.py
+++ b/modules/epicgames.py
@@ -54,7 +54,7 @@ class EpicGames:
                     id=_app,
                     name=_product_info["apps"][_app]["app_title"],
                 ),
-                data=_product_info["apps"][_app]["asset_info"]["build_version"],
+                data=_product_info["apps"][_app]["asset_infos"]["Windows"]["build_version"],
                 last_checked=self.timestamp,
                 last_updated=_last_updated,
             )

--- a/modules/epicgames.py
+++ b/modules/epicgames.py
@@ -11,7 +11,7 @@ from modules.models import App, Cache, Result
 class EpicGames:
     def __init__(self, app_ids, notifier, ignore_first):
         self.logger = logging.getLogger(__name__)
-        self.client = LegendaryCLI()
+        self.client = LegendaryCLI(api_timeout=10.0)
         self.old_result = {}
         self.new_result = {}
         self.timestamp = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ ms_cv==0.1.1
 
 discord-webhook==0.13.0
 
-legendary-gl==0.20.6
+legendary-gl==0.20.29
 
 tabulate==0.8.9


### PR DESCRIPTION
## Overview
Updated legendary-gl to 0.20.29 because Epic Games API was no longer logging in with sid.  
Corrected code accordingly.

## Change
- Updated legendary-gl to 0.20.29
- Set api_timeout in LegendaryCLI to 10.0 seconds
  (If the timeout is not set, it will be compared to None internally and an exception will occur.)
- Fix parsing of build_version