### PR TITLE
Bugfix for Steam games with old branches that lack "timeupdated"

### DIFF
--- a/helper/app_finder.py
+++ b/helper/app_finder.py
@@ -25,9 +25,9 @@ def gather_steam(id):
     _table = []
     for _branch in _product_info["apps"][_id]["depots"]["branches"]:
         _name = _product_info["apps"][_id]["common"]["name"]
-        _updated_time = _product_info["apps"][_id]["depots"]["branches"][_branch][
-            "timeupdated"
-        ]
+        _updated_time = -1
+        if "timeupdated" in _product_info["apps"][_id]["depots"]["branches"][_branch]:
+            _updated_time = _product_info["apps"][_id]["depots"]["branches"][_branch]["timeupdated"]
         _row = [
             "{}:{}".format(_id, _branch),
             _id,


### PR DESCRIPTION
fix #9
From issue:
Some games with old branches lack a timeupdated timestamp.
One example is Kenshi (ID 233860)