### PR TITLE
Send webhook messages when _apps is longer than 1024 characters.

### DIFF
--- a/modules/discord.py
+++ b/modules/discord.py
@@ -14,22 +14,17 @@ class Discord:
         self.user_ids = user_ids
         self.thumb_url = thumb_url
         self.embed_color = embed_color
-    def create_embed(self, description, timestamp, chunk):
+    def create_template_embed(self, description):
         _embed = DiscordEmbed(
             title="🚨 UPDATES ARE COMING",
             description=description,
             color=self.embed_color,
         )
         _embed.set_thumbnail(url=self.thumb_url)
-        _embed.add_embed_field(name="🎮 Updated Games", value=chunk)
-        _embed.add_embed_field(
-            name="🕑 Checked at", value=timestamp.strftime(f"%Y/%m/%d %H:%M:%S")
-        )
         _embed.set_footer(text="Notified by Game Update Notifier")
         _embed.set_timestamp()
         return _embed
-    def create_embed_messages(self, updated_apps, timestamp):
-
+    def create_embed_message(self, updated_apps, timestamp):
         _mention = ""
         for _role_id in self.role_ids:
             _mention += "<@&{}> ".format(_role_id)
@@ -45,28 +40,52 @@ class Discord:
                 _updated_app.name,
                 _updated_app.id,
             )
+
+        _embed_fields = []
         _embeds = []
         while _apps:
             idx = _apps.rfind("\n", 0, 1024)
             if idx != -1:
                 chunk = _apps[:idx + 1]
-                _embed = self.create_embed(_description, timestamp, chunk)
-                _embeds.append(_embed)
+                _embed_fields.append({'name': "🎮 Updated Games", 'value': chunk})
                 _apps = _apps[idx + 1:]
             else:
                 chunk = _apps[:1024]
-                _embed = self.create_embed(_description, timestamp, chunk)
+                _embed_fields.append({'name': "🎮 Updated Games", 'value': chunk})
+                _apps = _apps[1024:]
+
+        _first_embed = self.create_template_embed(description=_description)
+        _first_embed.add_embed_field(
+            name="🕑 Checked at", value=timestamp.strftime(f"%Y/%m/%d %H:%M:%S")
+        )
+        if len(_embed_fields) > 24:
+            # add 24 embeds to _first_embed, add the rest to new embeds.
+            for i in range(0, 24):
+                _first_embed.add_embed_field(name=_embed_fields[i]['name'], value=_embed_fields[i]['value'], inline=False)
+            _embeds.append(_first_embed)
+            _embed_fields = _embed_fields[24:]
+            for i in range(0, len(_embed_fields), 25):
+                _embed = self.create_template_embed(description=_description)
+                for k in range(i, i+25):
+                    if len(_embed_fields)<k+1: break
+                    _embed.add_embed_field(name=_embed_fields[k]['name'], value=_embed_fields[k]['value'], inline=False)
                 _embeds.append(_embed)
-                _apps = _apps[1024:]    
+        else:
+            for i in range(0, len(_embed_fields)):
+                _first_embed.add_embed_field(name=_embed_fields[i]['name'], value=_embed_fields[i]['value'], inline=False)
+            _embeds.append(_first_embed)
         return _embeds
 
     def fire(self, updated_apps, timestamp):
-        self.logger.info("Prepare webhook")
-        _webhook = DiscordWebhook(url=self.webhook_url)
+        #self.logger.info("Prepare webhook")
+        #_webhook = DiscordWebhook(url=self.webhook_url)
 
         self.logger.info("Construct embed message(s)")
-        _embeds = self.create_embed_messages(updated_apps, timestamp)
-        for _embed in _embeds:
-            self.logger.info("Post embed message")
-            _webhook.add_embed(_embed)
+        _embeds = self.create_embed_message(updated_apps, timestamp)
+
+        for i in range(0, len(_embeds), 10):
+            _webhook = DiscordWebhook(url=self.webhook_url)
+            for k in range(i, i+10):
+                if len(_embeds)<k+1: break
+                _webhook.add_embed(_embeds[k])
             _webhook.execute()

--- a/modules/discord.py
+++ b/modules/discord.py
@@ -14,8 +14,21 @@ class Discord:
         self.user_ids = user_ids
         self.thumb_url = thumb_url
         self.embed_color = embed_color
-
-    def create_embed_message(self, updated_apps, timestamp):
+    def create_embed(self, description, timestamp, chunk):
+        _embed = DiscordEmbed(
+            title="🚨 UPDATES ARE COMING",
+            description=description,
+            color=self.embed_color,
+        )
+        _embed.set_thumbnail(url=self.thumb_url)
+        _embed.add_embed_field(name="🎮 Updated Games", value=chunk)
+        _embed.add_embed_field(
+            name="🕑 Checked at", value=timestamp.strftime(f"%Y/%m/%d %H:%M:%S")
+        )
+        _embed.set_footer(text="Notified by Game Update Notifier")
+        _embed.set_timestamp()
+        return _embed
+    def create_embed_messages(self, updated_apps, timestamp):
 
         _mention = ""
         for _role_id in self.role_ids:
@@ -26,36 +39,34 @@ class Discord:
         _description = "{}\n".format(_mention)
         _description += "Updates have been detected on {}".format(self.platform)
 
-        _embed = DiscordEmbed(
-            title="🚨 UPDATES ARE COMING",
-            description=_description,
-            color=self.embed_color,
-        )
-
         _apps = ""
         for _updated_app in updated_apps:
             _apps += "💡 **{}** ({})\n".format(
                 _updated_app.name,
                 _updated_app.id,
             )
-
-        _embed.set_thumbnail(url=self.thumb_url)
-        _embed.add_embed_field(name="🎮 Updated Games", value=_apps)
-        _embed.add_embed_field(
-            name="🕑 Checked at", value=timestamp.strftime("%Y/%m/%d %H:%M:%S")
-        )
-        _embed.set_footer(text="Notified by Game Update Notifier")
-        _embed.set_timestamp()
-
-        return _embed
+        _embeds = []
+        while _apps:
+            idx = _apps.rfind("\n", 0, 1024)
+            if idx != -1:
+                chunk = _apps[:idx + 1]
+                _embed = self.create_embed(_description, timestamp, chunk)
+                _embeds.append(_embed)
+                _apps = _apps[idx + 1:]
+            else:
+                chunk = _apps[:1024]
+                _embed = self.create_embed(_description, timestamp, chunk)
+                _embeds.append(_embed)
+                _apps = _apps[1024:]    
+        return _embeds
 
     def fire(self, updated_apps, timestamp):
         self.logger.info("Prepare webhook")
         _webhook = DiscordWebhook(url=self.webhook_url)
 
-        self.logger.info("Construct embed message")
-        _embed = self.create_embed_message(updated_apps, timestamp)
-
-        self.logger.info("Post embed message")
-        _webhook.add_embed(_embed)
-        _webhook.execute()
+        self.logger.info("Construct embed message(s)")
+        _embeds = self.create_embed_messages(updated_apps, timestamp)
+        for _embed in _embeds:
+            self.logger.info("Post embed message")
+            _webhook.add_embed(_embed)
+            _webhook.execute()

--- a/modules/steam.py
+++ b/modules/steam.py
@@ -98,28 +98,33 @@ class Steam:
 
         self.old_result = copy.copy(self.new_result)
         for _app in self.apps:
-            key = _app.id + ":" + _app.filter
-            self.logger.info(
-                "Gather updated data from raw data for {} in branch: {}".format(
-                    _app.id, _app.filter
+            try:
+                key = _app.id + ":" + _app.filter
+                self.logger.info(
+                    "Gather updated data from raw data for {} in branch: {}".format(
+                        _app.id, _app.filter
+                    )
                 )
-            )
 
-            _last_updated = None
-            if self.old_result and key in self.old_result:
-                _last_updated = self.old_result[key].last_updated
-            key = _app.id + ":" + _app.filter
-            self.new_result[key] = Result(
-                app=App(
-                    id=key,
-                    name=_product_info["apps"][int(_app.id)]["common"]["name"],
-                ),
-                data=_product_info["apps"][int(_app.id)]["depots"]["branches"][
-                    _app.filter
-                ]["timeupdated"],
-                last_checked=self.timestamp,
-                last_updated=_last_updated,
-            )
+                _last_updated = None
+                if self.old_result and key in self.old_result:
+                    _last_updated = self.old_result[key].last_updated
+                key = _app.id + ":" + _app.filter
+                self.new_result[key] = Result(
+                    app=App(
+                        id=key,
+                        name=_product_info["apps"][int(_app.id)]["common"]["name"],
+                    ),
+                    data=_product_info["apps"][int(_app.id)]["depots"]["branches"][
+                        _app.filter
+                    ]["timeupdated"],
+                    last_checked=self.timestamp,
+                    last_updated=_last_updated,
+                )
+            except:
+                self.logger.warn(f"Removing: {_app.id}")
+                self.apps.remove(_app)
+                continue
 
         return
 
@@ -130,24 +135,28 @@ class Steam:
         _updated_apps = []
 
         for _app in self.apps:
-            key = _app.id + ":" + _app.filter
-            if (
-                self.old_result is {}
-                or key not in self.old_result
-                or self.old_result[key].data != self.new_result[key].data
-            ):
-                self.logger.info(
-                    "Update detected for: {} ({})".format(
-                        self.new_result[key].app.name, _app.filter
+            try:
+                key = _app.id + ":" + _app.filter
+                if (
+                    self.old_result is {}
+                    or key not in self.old_result
+                    or self.old_result[key].data != self.new_result[key].data
+                ):
+                    self.logger.info(
+                        "Update detected for: {} ({})".format(
+                            self.new_result[key].app.name, _app.filter
+                        )
                     )
-                )
 
-                self.logger.info("New data: {}".format(self.new_result[key].data))
-                _is_updated = True
-                _updated_apps.append(self.new_result[key].app)
+                    self.logger.info("New data: {}".format(self.new_result[key].data))
+                    _is_updated = True
+                    _updated_apps.append(self.new_result[key].app)
 
-                self.new_result[key].last_updated = self.timestamp
-                utils.replace_file(self.cache.latest_data, self.cache.old_data)
+                    self.new_result[key].last_updated = self.timestamp
+                    utils.replace_file(self.cache.latest_data, self.cache.old_data)
+            except:
+                self.logger.warn(".. ez miért")
+                continue
 
         self.logger.info("Cache filtered data as {}".format(self.cache.result))
         utils.save_dict_as_json(self.new_result, self.cache.result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ wheel==0.36.2
 python-dotenv==0.17.0
 
 steam==1.2.0
-gevent==21.1.2
+gevent==24.2.1
 gevent-eventemitter==2.1
 google-api-python-client==2.1.0
 


### PR DESCRIPTION
Because of [Discord's limits](https://discord.com/developers/docs/resources/channel#embed-limits), the webhook message will not be sent if `_apps` is longer than 1024 characters. My proposed solution is to create multiple embeds, with fields whose values are not longer than 1024 characters. I also tried to just create multiple fields within a single embed, but it looked bad.

Also had to bump gevent version in requirements.txt because I couldn't install the older version.